### PR TITLE
fixed lldp issue

### DIFF
--- a/napalm_ce/ce.py
+++ b/napalm_ce/ce.py
@@ -726,7 +726,7 @@ class CEDriver(NetworkDriver):
         results = {}
         command = 'display lldp neighbor brief'
         output = self.device.send_command(command)
-        re_lldp = r"(?P<local>\S+)\s+\d+\s+(?P<port>\S+)\s+(?P<hostname>\S+)"
+        re_lldp = r"(?P<local>\S+)\s+\d+\s+(?P<port>\S+)\s+?(?:$|(?P<hostname>\S+).+?$)"
         match = re.findall(re_lldp, output, re.M)
         for neighbor in match:
             local_iface = neighbor[0]


### PR DESCRIPTION
current lldp method dont work when lldp neighbor field was empty, for example, following input: 
```
Local Interface         Exptime(s) Neighbor Interface      Neighbor Device
-------------------------------------------------------------------------------
10GE1/0/17                     98  ffff-f89b-1f31
10GE1/0/25                     92  ffff-7fa0-d930          Broadcom 
10GE1/0/27                    109  ffff-7fa0-d870          nei1
10GE1/0/29                    109  ffff-7f3f-16ff          nei2
```

had following output:
```
{'10GE1/0/17': [{'hostname': '10GE1/0/25', 'port': 'ffff-f89b-1f31'}],
 '10GE1/0/27': [{'hostname': 'nei', 'port': 'ffff-7fa0-d870'},
 '10GE1/0/29': [{'hostname': 'nei2', 'port': 'ffff-7f3f-16ff'},
...
```
